### PR TITLE
Use `vmap_method` for `jax.pure_callback` on JAX>=0.6.0 and add tests

### DIFF
--- a/tests/test_scipy_nquad.py
+++ b/tests/test_scipy_nquad.py
@@ -1,0 +1,68 @@
+import sys
+import types
+
+import numpy as np
+
+
+fake_nb = types.SimpleNamespace(
+    types=types.SimpleNamespace(
+        double=lambda *args, **kwargs: None,
+        intc=object(),
+        CPointer=lambda x: None,
+    ),
+    cfunc=lambda sig: (lambda f: types.SimpleNamespace(ctypes=f)),
+    njit=lambda f: f,
+    carray=lambda params, shape: params,
+)
+sys.modules.setdefault('numba', fake_nb)
+
+import elisa.util.scipy_nquad as scipy_nquad
+
+
+def _setup_callback_mocks(monkeypatch, jax_version: str, expected_kwargs: dict):
+    monkeypatch.setattr(scipy_nquad.jax, '__version__', jax_version)
+    monkeypatch.setattr(scipy_nquad.jax, 'jit', lambda f: f)
+    monkeypatch.setattr(
+        scipy_nquad.jax,
+        'ShapeDtypeStruct',
+        lambda shape, dtype: {'shape': shape, 'dtype': dtype},
+    )
+    monkeypatch.setattr(scipy_nquad, 'LowLevelCallable', lambda cfun: cfun)
+    monkeypatch.setattr(
+        scipy_nquad.integrate,
+        'nquad',
+        lambda fun, ranges, args, opts, full_output=False: (42.0, 0.5),
+    )
+
+    captured = {}
+
+    def fake_pure_callback(cb, result_shape_dtype, ranges, args, **kwargs):
+        captured['kwargs'] = kwargs
+        captured['result_shape_dtype'] = result_shape_dtype
+        return cb(ranges, args)
+
+    monkeypatch.setattr(scipy_nquad.jax, 'pure_callback', fake_pure_callback)
+
+    out = scipy_nquad.NQuadTransform._nquad(
+        cfun=object(), opts=None, vectorized=True
+    )([[0.0, 1.0]], [1.0, 2.0])
+
+    assert captured['kwargs'] == expected_kwargs
+    assert captured['result_shape_dtype']['shape'] == (2,)
+    assert np.allclose(np.asarray(out), np.asarray([42.0, 0.5]))
+
+
+def test_nquad_transform_uses_vmap_method_for_jax_gte_060(monkeypatch):
+    _setup_callback_mocks(
+        monkeypatch,
+        jax_version='0.6.0',
+        expected_kwargs={'vmap_method': 'sequential'},
+    )
+
+
+def test_nquad_transform_uses_vectorized_for_jax_lt_060(monkeypatch):
+    _setup_callback_mocks(
+        monkeypatch,
+        jax_version='0.5.9',
+        expected_kwargs={'vectorized': True},
+    )


### PR DESCRIPTION
### Motivation

- Ensure compatibility with changes to `jax.pure_callback` keyword arguments introduced in newer JAX versions by selecting the appropriate kwargs at runtime. 

### Description

- Add `_parse_version` helper to parse JAX version strings into comparable tuples.
- Add `_pure_callback_kwargs` to return `{'vmap_method': 'sequential'}` for JAX >= 0.6.0 and preserve `{'vectorized': ...}` for older releases. 
- Use the returned kwargs in `NQuadTransform._nquad` when calling `jax.pure_callback` and add `re` import. 
- Add `tests/test_scipy_nquad.py` which fakes `numba` and `jax` behaviors and verifies the correct kwargs are passed for JAX versions `0.6.0` and `0.5.9`.

### Testing

- Added unit tests in `tests/test_scipy_nquad.py` which exercise both code paths and assert the `pure_callback` kwargs and returned values, and these tests passed locally. 
- The tests mock `numba`, `jax.jit`, `jax.ShapeDtypeStruct`, and `jax.pure_callback` to validate behavior without requiring the real dependencies, and they succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699ee6f7bea08324829a4987387d3bdc)